### PR TITLE
Add `R_CLEANCALL_SUPPORT` define for alternative compile time paths

### DIFF
--- a/src/cleancall.h
+++ b/src/cleancall.h
@@ -33,6 +33,8 @@ void cleancall_init(void);
 // Public API
 // --------------------------------------------------------------------
 
+#define R_CLEANCALL_SUPPORT 1
+
 SEXP r_with_cleanup_context(SEXP (*fn)(void* data), void* data);
 void r_call_on_exit(void (*fn)(void* data), void* data);
 void r_call_on_early_exit(void (*fn)(void* data), void* data);


### PR DESCRIPTION
Needed by cli to optionally support cleancall in the progress API, like
https://github.com/r-lib/cli/blob/bc503509cddb65d0007aeb301936e27de76bc7d7/inst/include/cli/progress.h#L298-L302