### PR TITLE
`callbacks` is always initialized to `R_NilValue` by `cleancall_init()`

### DIFF
--- a/src/cleancall.c
+++ b/src/cleancall.c
@@ -125,8 +125,6 @@ SEXP r_with_cleanup_context(SEXP (*fn)(void* data), void* data) {
   SEXP new = PROTECT(Rf_cons(R_NilValue, R_NilValue));
   push_callback(new);
 
-  if (!callbacks) callbacks = R_NilValue;
-
   SEXP old = callbacks;
   callbacks = new;
 


### PR DESCRIPTION
This was added in response to a strict write barrier issue here https://github.com/r-lib/cleancall/issues/10#issuecomment-632338648

But since then, `callbacks` has been tweaked to ensure that it is initialized to `R_NilValue` at package load time (https://github.com/r-lib/cleancall/commit/787588540d5710e5949488d141e51e7c1e0fe5f8), so this branch should never actually run IIUC.