### PR TITLE
Include `Rinternals.h` to access `SEXP` and make the header standalone

### DIFF
--- a/src/cleancall.h
+++ b/src/cleancall.h
@@ -2,6 +2,7 @@
 #define CLEANCALL_H
 
 #include <Rversion.h>
+#include <Rinternals.h>
 #include <R_ext/Rdynload.h>
 
 // --------------------------------------------------------------------


### PR DESCRIPTION
Otherwise `SEXP` isn't defined and you have to include `Rinternals.h` before `cleancall.h` when you embed or use cleancall, which I don't think is very good practice