### PR TITLE
Add C++ support through `extern "C"`

### DIFF
--- a/src/cleancall.h
+++ b/src/cleancall.h
@@ -5,6 +5,10 @@
 #include <Rinternals.h>
 #include <R_ext/Rdynload.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // --------------------------------------------------------------------
 // Internals
 // --------------------------------------------------------------------
@@ -39,5 +43,9 @@ void cleancall_init(void);
 SEXP r_with_cleanup_context(SEXP (*fn)(void* data), void* data);
 void r_call_on_exit(void (*fn)(void* data), void* data);
 void r_call_on_early_exit(void (*fn)(void* data), void* data);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Matches what is done in cli's `testprogress` test folder

Seems to work properly in purrr if I change purrr over to use C++ internally everywhere rather than C. Without this, I get the expected errors like

```
symbol not found in flat namespace (__Z14cleancall_callP7SEXPRECS0_)
```